### PR TITLE
Fix definition of clique number and independence number in graphs lecture

### DIFF
--- a/lec_graphs.tex
+++ b/lec_graphs.tex
@@ -477,11 +477,11 @@
 		\begin{itemize}
 			\item Die \alert{Cliquenzahl} von $G$ ist definiert als
 				\begin{align*}
-					\omega(G)=\max\cbc{S:S\mbox{ ist eine Clique in }G}.
+					\omega(G)=\max\cbc{|S|:S\mbox{ ist eine Clique in }G}.
 				\end{align*}
 			\item Die \alert{Stabilit\"atszahl} von $G$ ist definiert als
 				\begin{align*}
-					\alpha(G)=\max\cbc{S:S\mbox{ ist eine stabile Menge in }G}.
+					\alpha(G)=\max\cbc{|S|:S\mbox{ ist eine stabile Menge in }G}.
 				\end{align*}
 		\end{itemize}
 	\end{block}


### PR DESCRIPTION
The absolute value of the set $S$ is missing in the definition of clique number and independence number in `lec_graphs.tex`.